### PR TITLE
fix: correct special character validation in add/edit author modals (#1)

### DIFF
--- a/src/main/webapp/authors.jsp
+++ b/src/main/webapp/authors.jsp
@@ -116,8 +116,8 @@
 	                                class="form-control" 
 	                                id="addAuthorName" 
 	                                name="addAuthorName" 
-	                                pattern="[A-Za-zÀ-ÿ\s]+" 
-	                                oninput="this.value = this.value.replace(/[^A-Za-zÀ-ÿ\s]/g, '');" 
+	                                pattern="[A-Za-zÀ-ÿ\s.]+" 
+	                                oninput="this.value = this.value.replace(/[^A-Za-zÀ-ÿ\s.]/g, '');" 
 	                                placeholder="Ingrese el nombre del autor" 
 	                                required
 	                            >
@@ -343,8 +343,8 @@
 	                                class="form-control" 
 	                                id="editAuthorName" 
 	                                name="editAuthorName" 
-	                                pattern="[A-Za-zÀ-ÿ\s]+" 
-	                                oninput="this.value = this.value.replace(/[^A-Za-zÀ-ÿ\s]/g, '');" 
+	                                pattern="[A-Za-zÀ-ÿ\s.]+" 
+	                                oninput="this.value = this.value.replace(/[^A-Za-zÀ-ÿ\s.]/g, '');" 
 	                                placeholder="Ingrese el nombre del autor" 
 	                                required
 	                            >


### PR DESCRIPTION
This PR updates special character validation in the add/edit author modals to allow the (.) character, ensuring security and data integrity.

Closes #1